### PR TITLE
Make `multibody::Visualizer` asynchronous

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,42 @@
 
 Candlewick is a WIP library for a renderer based on SDL3's new [GPU API](https://wiki.libsdl.org/SDL3/CategoryGPU).
 
+## Features
+
+Candlewick comes with some basic graphical features.
+
+* Shadow mapping using directional shadow maps
+* Screen-space ambient occlusion (SSAO)
+* **WIP:** Screen-space shadows (SSS)
+
+### Pinocchio visualizer
+
+Candlewick visualization utilities for robotics based on Pinocchio.
+
+You can load a Pinocchio model, its geometry model, and create a visualizer that can be used similar to the other visualizers included in `pinocchio.visualize`.
+Here's a Python example:
+
+```python
+import example_robot_data as erd
+import pinocchio as pin
+import numpy as np
+from candlewick.multibody import Visualizer, VisualizerConfig
+
+robot = erd.load("ur10")
+model: pin.Model = robot.model
+data: pin.Data = robot.data
+visual_model = robot.visual_model
+
+config = VisualizerConfig()
+config.width = 1280
+config.height = 720
+viz = Visualizer(config, model, visual_model)
+
+q0 = pin.neutral(model)
+viz.setCameraPose(pin.SE3.Identity())
+viz.display(q0)
+```
+
 
 ## Installation
 
@@ -26,4 +62,5 @@ Candlewick depends mainly on:
 * [FFmpeg](https://ffmpeg.org/) for support for recording videos from the rendered graphics.
 * For loading and visualizing robots:
   * the Pinocchio rigid-body dynamics library (required for the `candlewick::multibody` classes and functions).
+  * the [pinocchio-visualizers](https://github.com/Simple-Robotics/pinocchio-visualizers) header-only library, which provides a skeleton for creating a C++ visualizer for Pinocchio and a visitor used for Python bindings
   * [robot_descriptions_cpp](https://github.com/ManifoldFR/robot_descriptions_cpp), a suite of loaders for robots (required for some examples)

--- a/python/src/expose-visualizer.cpp
+++ b/python/src/expose-visualizer.cpp
@@ -19,5 +19,6 @@ void exposeVisualizer() {
                     const pin::GeometryModel &>(
           ("self"_a, "config", "model", "geomModel")))
       .def(pinocchio_visualizers::VisualizerVisitor<Visualizer>{})
-      .def_readonly("renderer", &Visualizer::renderer);
+      .def_readonly("renderer", &Visualizer::renderer)
+      .add_property("shouldExit", &Visualizer::shouldExit);
 }

--- a/src/candlewick/core/DebugScene.cpp
+++ b/src/candlewick/core/DebugScene.cpp
@@ -99,6 +99,7 @@ void DebugScene::setupPipelines(const MeshLayout &layout) {
                    .num_color_targets = 1,
                    .depth_stencil_format = _depthFormat,
                    .has_depth_stencil_target = true},
+      .props = 0,
   };
   if (!_trianglePipeline)
     _trianglePipeline = SDL_CreateGPUGraphicsPipeline(_device, &info);

--- a/src/candlewick/core/GuiSystem.h
+++ b/src/candlewick/core/GuiSystem.h
@@ -1,4 +1,5 @@
 #include "Core.h"
+#include "Tags.h"
 #include <functional>
 
 namespace candlewick {
@@ -7,13 +8,17 @@ class GuiSystem {
 public:
   using GuiBehavior = std::function<void(Renderer &)>;
 
-  GuiSystem(GuiBehavior behav) : callback_(behav) {}
+  GuiSystem(NoInitT, GuiBehavior behav) : callback_(behav) {}
+  GuiSystem(const Renderer &renderer, GuiBehavior behav);
 
   bool init(const Renderer &renderer);
   void render(Renderer &renderer);
   void release();
 
   GuiBehavior callback_;
+
+private:
+  bool _initialized = false;
 };
 
 } // namespace candlewick

--- a/src/candlewick/core/Renderer.cpp
+++ b/src/candlewick/core/Renderer.cpp
@@ -5,7 +5,7 @@
 
 namespace candlewick {
 Renderer::Renderer(Device &&device, SDL_Window *window)
-    : device(std::move(device)), window(window) {
+    : device(std::move(device)), window(window), swapchain(nullptr) {
   if (!SDL_ClaimWindowForGPUDevice(this->device, this->window))
     throw RAIIException(SDL_GetError());
 }

--- a/src/candlewick/core/Renderer.h
+++ b/src/candlewick/core/Renderer.h
@@ -32,6 +32,8 @@ struct Renderer {
   /// Submit the command buffer, ending the frame.
   void endFrame() { SDL_SubmitGPUCommandBuffer(command_buffer); }
 
+  void cancelFrame() { SDL_CancelGPUCommandBuffer(command_buffer); }
+
   bool waitAndAcquireSwapchain() {
     return SDL_WaitAndAcquireGPUSwapchainTexture(command_buffer, window,
                                                  &swapchain, NULL, NULL);
@@ -41,6 +43,8 @@ struct Renderer {
     return SDL_AcquireGPUSwapchainTexture(command_buffer, window, &swapchain,
                                           NULL, NULL);
   }
+
+  bool waitForSwapchain() { return SDL_WaitForGPUSwapchain(device, window); }
 
   SDL_GPUTextureFormat getSwapchainTextureFormat() const {
     return SDL_GetGPUSwapchainTextureFormat(device, window);

--- a/src/candlewick/core/Renderer.h
+++ b/src/candlewick/core/Renderer.h
@@ -138,9 +138,12 @@ namespace rend {
                               Uint32(bindings.size()));
   }
 
-  template <Uint32 N>
-  void bindVertexSamplers(SDL_GPURenderPass *pass, Uint32 first_slot,
-                          SDL_GPUTextureSamplerBinding sampler_bindings[N]) {
+  /// \copybrief bindFragmentSamplers()
+  /// This overload exists to enable taking a brace-initialized array.
+  template <std::size_t N>
+  void bindVertexSamplers(
+      SDL_GPURenderPass *pass, Uint32 first_slot,
+      const SDL_GPUTextureSamplerBinding (&sampler_bindings)[N]) {
     SDL_BindGPUVertexSamplers(pass, first_slot, sampler_bindings, N);
   }
 
@@ -159,10 +162,12 @@ namespace rend {
                                 Uint32(bindings.size()));
   }
 
-  /// \sa bindFragmentSamplers()
-  template <Uint32 N>
-  void bindFragmentSamplers(SDL_GPURenderPass *pass, Uint32 first_slot,
-                            SDL_GPUTextureSamplerBinding sampler_bindings[N]) {
+  /// \copybrief bindFragmentSamplers()
+  /// This overload exists to enable taking a brace-initialized array.
+  template <std::size_t N>
+  void bindFragmentSamplers(
+      SDL_GPURenderPass *pass, Uint32 first_slot,
+      const SDL_GPUTextureSamplerBinding (&sampler_bindings)[N]) {
     SDL_BindGPUFragmentSamplers(pass, first_slot, sampler_bindings, N);
   }
 

--- a/src/candlewick/core/Renderer.h
+++ b/src/candlewick/core/Renderer.h
@@ -115,36 +115,6 @@ struct Renderer {
     SDL_PushGPUFragmentUniformData(command_buffer, slot_index, data, length);
   }
 
-  /// \brief Bind texture-sampler pair for vertex shader.
-  void bindVertexSampler(SDL_GPURenderPass *pass, Uint32 first_slot,
-                         const SDL_GPUTextureSamplerBinding &binding);
-
-  void
-  bindVertexSamplers(SDL_GPURenderPass *pass, Uint32 first_slot,
-                     std::span<const SDL_GPUTextureSamplerBinding> bindings);
-
-  template <Uint32 N>
-  void bindVertexSamplers(SDL_GPURenderPass *pass, Uint32 first_slot,
-                          SDL_GPUTextureSamplerBinding sampler_bindings[N]) {
-    SDL_BindGPUVertexSamplers(pass, first_slot, sampler_bindings, N);
-  }
-
-  /// \brief Bind texture-sampler pair for fragment shader.
-  void bindFragmentSampler(SDL_GPURenderPass *pass, Uint32 first_slot,
-                           const SDL_GPUTextureSamplerBinding &binding);
-
-  /// \brief Bind multiple samplers.
-  /// \sa bindFragmentSampler()
-  void
-  bindFragmentSamplers(SDL_GPURenderPass *pass, Uint32 first_slot,
-                       std::span<const SDL_GPUTextureSamplerBinding> bindings);
-
-  template <Uint32 N>
-  void bindFragmentSamplers(SDL_GPURenderPass *pass, Uint32 first_slot,
-                            SDL_GPUTextureSamplerBinding sampler_bindings[N]) {
-    SDL_BindGPUVertexSamplers(pass, first_slot, sampler_bindings, N);
-  }
-
   void destroy() {
     SDL_ReleaseWindowFromGPUDevice(device, window);
     depth_texture.release();
@@ -152,30 +122,49 @@ struct Renderer {
   }
 };
 
-inline void
-Renderer::bindVertexSampler(SDL_GPURenderPass *pass, Uint32 first_slot,
-                            const SDL_GPUTextureSamplerBinding &binding) {
-  SDL_BindGPUVertexSamplers(pass, first_slot, &binding, 1);
-}
+namespace rend {
+  /// \brief Bind single texture-sampler pair for vertex shader.
+  inline void bindVertexSampler(SDL_GPURenderPass *pass, Uint32 first_slot,
+                                const SDL_GPUTextureSamplerBinding &binding) {
+    SDL_BindGPUVertexSamplers(pass, first_slot, &binding, 1);
+  }
 
-inline void Renderer::bindVertexSamplers(
-    SDL_GPURenderPass *pass, Uint32 first_slot,
-    std::span<const SDL_GPUTextureSamplerBinding> bindings) {
-  SDL_BindGPUVertexSamplers(pass, first_slot, bindings.data(),
-                            Uint32(bindings.size()));
-}
-
-inline void
-Renderer::bindFragmentSampler(SDL_GPURenderPass *pass, Uint32 first_slot,
-                              const SDL_GPUTextureSamplerBinding &binding) {
-  SDL_BindGPUFragmentSamplers(pass, first_slot, &binding, 1);
-}
-
-inline void Renderer::bindFragmentSamplers(
-    SDL_GPURenderPass *pass, Uint32 first_slot,
-    std::span<const SDL_GPUTextureSamplerBinding> bindings) {
-  SDL_BindGPUFragmentSamplers(pass, first_slot, bindings.data(),
+  /// \brief Bind multiple fragment shader samplers.
+  /// \sa bindVertexSampler()
+  inline void
+  bindVertexSamplers(SDL_GPURenderPass *pass, Uint32 first_slot,
+                     std::span<const SDL_GPUTextureSamplerBinding> bindings) {
+    SDL_BindGPUVertexSamplers(pass, first_slot, bindings.data(),
                               Uint32(bindings.size()));
-}
+  }
 
+  template <Uint32 N>
+  void bindVertexSamplers(SDL_GPURenderPass *pass, Uint32 first_slot,
+                          SDL_GPUTextureSamplerBinding sampler_bindings[N]) {
+    SDL_BindGPUVertexSamplers(pass, first_slot, sampler_bindings, N);
+  }
+
+  /// \brief Bind single texture-sampler pair for fragment shader.
+  inline void bindFragmentSampler(SDL_GPURenderPass *pass, Uint32 first_slot,
+                                  const SDL_GPUTextureSamplerBinding &binding) {
+    SDL_BindGPUFragmentSamplers(pass, first_slot, &binding, 1);
+  }
+
+  /// \brief Bind multiple fragment shader samplers.
+  /// \sa bindFragmentSampler()
+  inline void
+  bindFragmentSamplers(SDL_GPURenderPass *pass, Uint32 first_slot,
+                       std::span<const SDL_GPUTextureSamplerBinding> bindings) {
+    SDL_BindGPUFragmentSamplers(pass, first_slot, bindings.data(),
+                                Uint32(bindings.size()));
+  }
+
+  /// \sa bindFragmentSamplers()
+  template <Uint32 N>
+  void bindFragmentSamplers(SDL_GPURenderPass *pass, Uint32 first_slot,
+                            SDL_GPUTextureSamplerBinding sampler_bindings[N]) {
+    SDL_BindGPUFragmentSamplers(pass, first_slot, sampler_bindings, N);
+  }
+
+} // namespace rend
 } // namespace candlewick

--- a/src/candlewick/core/Renderer.h
+++ b/src/candlewick/core/Renderer.h
@@ -17,14 +17,17 @@ namespace candlewick {
 /// \sa Mesh
 struct Renderer {
   Device device;
-  SDL_Window *window = nullptr;
+  SDL_Window *window;
   SDL_GPUTexture *swapchain;
   Texture depth_texture{NoInit};
-  SDL_GPUCommandBuffer *command_buffer;
+  SDL_GPUCommandBuffer *command_buffer = nullptr;
 
+  Renderer(NoInitT) : device(NoInit), window(nullptr), swapchain(nullptr) {}
   Renderer(Device &&device, SDL_Window *window);
   Renderer(Device &&device, SDL_Window *window,
            SDL_GPUTextureFormat suggested_depth_format);
+
+  bool initialized() { return bool(device); }
 
   /// Acquire the command buffer, starting a frame.
   void beginFrame() { command_buffer = SDL_AcquireGPUCommandBuffer(device); }

--- a/src/candlewick/core/debug/DepthViz.cpp
+++ b/src/candlewick/core/debug/DepthViz.cpp
@@ -73,11 +73,11 @@ void renderDepthDebug(Renderer &renderer, const DepthDebugPass &pass,
 
   SDL_BindGPUGraphicsPipeline(render_pass, pass.pipeline);
 
-  renderer.bindFragmentSampler(render_pass, 0,
-                               {
-                                   .texture = pass.depthTexture,
-                                   .sampler = pass.sampler,
-                               });
+  rend::bindFragmentSampler(render_pass, 0,
+                            {
+                                .texture = pass.depthTexture,
+                                .sampler = pass.sampler,
+                            });
 
   cam_param_ubo_t cam_ubo{opts.mode, opts.near, opts.far,
                           opts.cam_proj == CameraProjection::ORTHOGRAPHIC};

--- a/src/candlewick/multibody/LoadCoalPrimitives.cpp
+++ b/src/candlewick/multibody/LoadCoalPrimitives.cpp
@@ -16,9 +16,9 @@ namespace candlewick {
 
 constexpr float kPlaneScale = 10.f;
 
-void getPlaneOrHalfspaceNormalOffset(
-    const hpp::fcl::CollisionGeometry &geometry, Float3 &n, float &d) {
-  using namespace hpp::fcl;
+void getPlaneOrHalfspaceNormalOffset(const coal::CollisionGeometry &geometry,
+                                     Float3 &n, float &d) {
+  using namespace coal;
   switch (geometry.getNodeType()) {
   case GEOM_PLANE: {
     const Plane &g = static_cast<const Plane &>(geometry);
@@ -38,9 +38,9 @@ void getPlaneOrHalfspaceNormalOffset(
   }
 }
 
-MeshData loadCoalPrimitive(const hpp::fcl::CollisionGeometry &geometry,
+MeshData loadCoalPrimitive(const coal::CollisionGeometry &geometry,
                            const Float4 &meshColor, const Float3 &meshScale) {
-  using namespace hpp::fcl;
+  using namespace coal;
   SDL_assert_always(geometry.getObjectType() == OT_GEOM);
   MeshData meshData{NoInit};
   Eigen::Affine3f transform = Eigen::Affine3f::Identity();

--- a/src/candlewick/multibody/LoadCoalPrimitives.h
+++ b/src/candlewick/multibody/LoadCoalPrimitives.h
@@ -3,11 +3,11 @@
 #include "../utils/Utils.h"
 #include "../core/math_types.h"
 
-#include <hpp/fcl/fwd.hh>
+#include <coal/fwd.hh>
 
 namespace candlewick {
 
-MeshData loadCoalPrimitive(const hpp::fcl::CollisionGeometry &geometry,
+MeshData loadCoalPrimitive(const coal::CollisionGeometry &geometry,
                            const Float4 &meshColor, const Float3 &meshScale);
 
 MeshData loadCoalHeightField(const coal::CollisionGeometry &collGeom);

--- a/src/candlewick/multibody/LoadPinocchioGeometry.cpp
+++ b/src/candlewick/multibody/LoadPinocchioGeometry.cpp
@@ -6,14 +6,12 @@
 #include <pinocchio/multibody/geometry.hpp>
 
 namespace candlewick::multibody {
-using hpp::fcl::CollisionGeometry;
 
 void loadGeometryObject(const pin::GeometryObject &gobj,
                         std::vector<MeshData> &meshData) {
-  using hpp::fcl::OBJECT_TYPE;
-  using enum OBJECT_TYPE;
+  using namespace coal;
 
-  const CollisionGeometry &collgom = *gobj.geometry.get();
+  const coal::CollisionGeometry &collgom = *gobj.geometry.get();
   const OBJECT_TYPE objType = collgom.getObjectType();
 
   Float4 meshColor = gobj.meshColor.cast<float>();

--- a/src/candlewick/multibody/RobotScene.cpp
+++ b/src/candlewick/multibody/RobotScene.cpp
@@ -289,17 +289,17 @@ void RobotScene::renderPBRTriangleGeometry(Renderer &renderer,
                     _config.enable_normal_target, gBuffer);
 
   if (enable_shadows) {
-    renderer.bindFragmentSampler(render_pass, SHADOW_MAP_SLOT,
-                                 {
-                                     .texture = shadowPass.depthTexture,
-                                     .sampler = shadowPass.sampler,
-                                 });
+    rend::bindFragmentSampler(render_pass, SHADOW_MAP_SLOT,
+                              {
+                                  .texture = shadowPass.depthTexture,
+                                  .sampler = shadowPass.sampler,
+                              });
   }
-  renderer.bindFragmentSampler(render_pass, SSAO_SLOT,
-                               {
-                                   .texture = ssaoPass.ssaoMap,
-                                   .sampler = ssaoPass.texSampler,
-                               });
+  rend::bindFragmentSampler(render_pass, SSAO_SLOT,
+                            {
+                                .texture = ssaoPass.ssaoMap,
+                                .sampler = ssaoPass.texSampler,
+                            });
   renderer.pushFragmentUniform(FragmentUniformSlots::LIGHTING, &lightUbo,
                                sizeof(lightUbo));
   int _useSsao = useSsao;

--- a/src/candlewick/multibody/RobotScene.cpp
+++ b/src/candlewick/multibody/RobotScene.cpp
@@ -157,7 +157,7 @@ void RobotScene::initGBuffer(const Renderer &renderer) {
   int width, height;
   SDL_GetWindowSize(renderer.window, &width, &height);
   gBuffer.normalMap = Texture{renderer.device,
-                              SDL_GPUTextureCreateInfo{
+                              {
                                   .type = SDL_GPU_TEXTURETYPE_2D,
                                   .format = SDL_GPU_TEXTUREFORMAT_R16G16_FLOAT,
                                   .usage = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET |
@@ -167,6 +167,7 @@ void RobotScene::initGBuffer(const Renderer &renderer) {
                                   .layer_count_or_depth = 1,
                                   .num_levels = 1,
                                   .sample_count = SDL_GPU_SAMPLECOUNT_1,
+                                  .props = 0,
                               },
                               "GBuffer normal"};
 }
@@ -204,7 +205,9 @@ void RobotScene::collectOpaqueCastables() {
 }
 
 void RobotScene::render(Renderer &renderer, const Camera &camera) {
-  ssaoPass.render(renderer, camera);
+  if (_config.enable_ssao) {
+    ssaoPass.render(renderer, camera);
+  }
 
   // render geometry which participated in the prepass
   renderPBRTriangleGeometry(renderer, camera);
@@ -302,7 +305,7 @@ void RobotScene::renderPBRTriangleGeometry(Renderer &renderer,
                             });
   renderer.pushFragmentUniform(FragmentUniformSlots::LIGHTING, &lightUbo,
                                sizeof(lightUbo));
-  int _useSsao = useSsao;
+  int _useSsao = _config.enable_ssao;
   renderer.pushFragmentUniform(2, &_useSsao, sizeof(_useSsao));
 
   auto *pipeline = renderPipelines[PIPELINE_TRIANGLEMESH];

--- a/src/candlewick/multibody/RobotScene.h
+++ b/src/candlewick/multibody/RobotScene.h
@@ -98,6 +98,7 @@ namespace multibody {
       };
       bool enable_msaa = false;
       bool enable_shadows = true;
+      bool enable_ssao = true;
       bool triangle_has_prepass = false;
       bool enable_normal_target = false;
       SDL_GPUSampleCount msaa_samples = SDL_GPU_SAMPLECOUNT_1;
@@ -131,12 +132,15 @@ namespace multibody {
     void renderOtherGeometry(Renderer &renderer, const Camera &camera);
     void release();
 
+    Config &config() { return _config; }
     const Config &config() const { return _config; }
     inline bool pbrHasPrepass() const { return _config.triangle_has_prepass; }
     inline bool shadowsEnabled() const { return _config.enable_shadows; }
 
     /// \brief Getter for the referenced pinocchio GeometryData object.
     const pin::GeometryData &geomData() const { return *_geomData; }
+
+    const entt::registry &registry() const { return _registry; }
 
     void initGBuffer(const Renderer &renderer);
 
@@ -148,7 +152,6 @@ namespace multibody {
     } gBuffer;
     ShadowPassInfo shadowPass;
     AABB worldSpaceBounds;
-    bool useSsao = true;
 
   private:
     entt::registry &_registry;

--- a/src/candlewick/multibody/Visualizer.h
+++ b/src/candlewick/multibody/Visualizer.h
@@ -36,18 +36,19 @@ struct CameraControlParams {
   } modifiers;
 };
 
-/// \brief A synchronous renderer. The display() function will perform the draw
-/// calls.
+/// \brief A Pinocchio robot visualizer. The display() function will perform the
+/// draw calls.
 class Visualizer final : public BaseVisualizer {
 public:
   using BaseVisualizer::setCameraPose;
   entt::registry registry;
   Renderer renderer;
-  GuiSystem guiSys;
-  RobotScene robotScene;
-  DebugScene debugScene;
+  GuiSystem guiSystem;
+  std::optional<RobotScene> robotScene;
+  std::optional<DebugScene> debugScene;
   Camera camera;
   CameraControlParams cameraParams;
+  std::mutex vis_mutex;
 
   static constexpr Radf DEFAULT_FOV = 55.0_radf;
 
@@ -93,9 +94,9 @@ public:
 
   /// \brief Clear objects
   void clean() override {
-    robotScene.clearEnvironment();
-    robotScene.clearRobotGeometries();
-    debugScene.registry().clear();
+    robotScene->clearEnvironment();
+    robotScene->clearRobotGeometries();
+    debugScene->registry().clear();
   }
 
 private:

--- a/src/candlewick/multibody/Visualizer.h
+++ b/src/candlewick/multibody/Visualizer.h
@@ -49,6 +49,8 @@ public:
   Camera camera;
   CameraControlParams cameraParams;
 
+  static constexpr Radf DEFAULT_FOV = 55.0_radf;
+
   struct Config {
     Uint32 width;
     Uint32 height;
@@ -61,6 +63,7 @@ public:
   /// to the Visualizer constructor to change this behaviour.
   static void default_gui_exec(Visualizer &viz);
 
+  void resetCamera();
   void loadViewerModel() override;
 
   Visualizer(const Config &config, const pin::Model &model,
@@ -101,7 +104,7 @@ private:
 };
 
 inline Renderer Visualizer::createRenderer(const Config &config) {
-  bool ret = SDL_Init(SDL_INIT_VIDEO);
+  [[maybe_unused]] bool ret = SDL_Init(SDL_INIT_VIDEO);
   assert(ret);
   Device dev{auto_detect_shader_format_subset()};
   SDL_Window *window =

--- a/src/candlewick/multibody/internal/visualizer_gui.cpp
+++ b/src/candlewick/multibody/internal/visualizer_gui.cpp
@@ -32,7 +32,7 @@ void camera_params_gui(CameraControlParams &params) {
 
 void Visualizer::default_gui_exec(Visualizer &viz) {
   auto &render = viz.renderer;
-  auto &light = viz.robotScene.directionalLight;
+  auto &light = viz.robotScene->directionalLight;
   ImGui::Begin("Renderer info & controls", nullptr,
                ImGuiWindowFlags_AlwaysAutoResize);
   ImGui::Text("Device driver: %s", render.device.driverName());

--- a/src/candlewick/posteffects/SSAO.cpp
+++ b/src/candlewick/posteffects/SSAO.cpp
@@ -190,21 +190,13 @@ namespace ssao {
     SDL_GPURenderPass *render_pass = SDL_BeginGPURenderPass(
         renderer.command_buffer, &color_info, 1, nullptr);
 
-    rend::bindFragmentSampler(render_pass, 0,
-                              {
-                                  .texture = inDepthMap,
-                                  .sampler = texSampler,
-                              });
-    rend::bindFragmentSampler(render_pass, 1,
-                              {
-                                  .texture = inNormalMap,
-                                  .sampler = texSampler,
-                              });
-    rend::bindFragmentSampler(render_pass, 2,
-                              {
-                                  .texture = ssaoNoise.tex,
-                                  .sampler = ssaoNoise.sampler,
-                              });
+    rend::bindFragmentSamplers(
+        render_pass, 0,
+        {
+            {.texture = inDepthMap, .sampler = texSampler},
+            {.texture = inNormalMap, .sampler = texSampler},
+            {.texture = ssaoNoise.tex, .sampler = ssaoNoise.sampler},
+        });
     auto SAMPLES_PAYLOAD_BYTES =
         Uint32(KERNEL_SAMPLES.size() * sizeof(GpuVec4));
     renderer.pushFragmentUniform(0, KERNEL_SAMPLES.data(),

--- a/src/candlewick/posteffects/SSAO.cpp
+++ b/src/candlewick/posteffects/SSAO.cpp
@@ -190,21 +190,21 @@ namespace ssao {
     SDL_GPURenderPass *render_pass = SDL_BeginGPURenderPass(
         renderer.command_buffer, &color_info, 1, nullptr);
 
-    renderer.bindFragmentSampler(render_pass, 0,
-                                 {
-                                     .texture = inDepthMap,
-                                     .sampler = texSampler,
-                                 });
-    renderer.bindFragmentSampler(render_pass, 1,
-                                 {
-                                     .texture = inNormalMap,
-                                     .sampler = texSampler,
-                                 });
-    renderer.bindFragmentSampler(render_pass, 2,
-                                 {
-                                     .texture = ssaoNoise.tex,
-                                     .sampler = ssaoNoise.sampler,
-                                 });
+    rend::bindFragmentSampler(render_pass, 0,
+                              {
+                                  .texture = inDepthMap,
+                                  .sampler = texSampler,
+                              });
+    rend::bindFragmentSampler(render_pass, 1,
+                              {
+                                  .texture = inNormalMap,
+                                  .sampler = texSampler,
+                              });
+    rend::bindFragmentSampler(render_pass, 2,
+                              {
+                                  .texture = ssaoNoise.tex,
+                                  .sampler = ssaoNoise.sampler,
+                              });
     auto SAMPLES_PAYLOAD_BYTES =
         Uint32(KERNEL_SAMPLES.size() * sizeof(GpuVec4));
     renderer.pushFragmentUniform(0, KERNEL_SAMPLES.data(),
@@ -225,7 +225,7 @@ namespace ssao {
       SDL_BindGPUGraphicsPipeline(render_pass, blurPipeline);
 
       renderer.pushFragmentUniform(0, &blurDir, sizeof(blurDir));
-      renderer.bindFragmentSampler(
+      rend::bindFragmentSampler(
           render_pass, 0,
           {
               .texture = (i == 0) ? ssaoMap : blurPass1Tex,

--- a/src/candlewick/posteffects/ScreenSpaceShadows.cpp
+++ b/src/candlewick/posteffects/ScreenSpaceShadows.cpp
@@ -115,11 +115,11 @@ namespace effects {
         config.numSteps,
     };
     renderer.pushFragmentUniform(0, &ubo, sizeof(ubo));
-    renderer.bindFragmentSampler(render_pass, 0,
-                                 {
-                                     .texture = depthTexture,
-                                     .sampler = depthSampler,
-                                 });
+    rend::bindFragmentSampler(render_pass, 0,
+                              {
+                                  .texture = depthTexture,
+                                  .sampler = depthSampler,
+                              });
 
     for (auto &cs : castables) {
       GpuMat4 mvp = vp * cs.transform;

--- a/src/candlewick/primitives/Heightfield.cpp
+++ b/src/candlewick/primitives/Heightfield.cpp
@@ -4,9 +4,9 @@
 
 namespace candlewick {
 
-MeshData loadHeightfield(const Eigen::MatrixXf &heights,
-                         const Eigen::VectorXf &xgrid,
-                         const Eigen::VectorXf &ygrid) {
+MeshData loadHeightfield(const Eigen::Ref<const Eigen::MatrixXf> &heights,
+                         const Eigen::Ref<const Eigen::VectorXf> &xgrid,
+                         const Eigen::Ref<const Eigen::VectorXf> &ygrid) {
   SDL_assert(heights.rows() == xgrid.size());
   SDL_assert(heights.cols() == ygrid.size());
   const auto nx = (Sint32)heights.rows();

--- a/src/candlewick/primitives/Heightfield.h
+++ b/src/candlewick/primitives/Heightfield.h
@@ -5,7 +5,7 @@
 namespace candlewick {
 
 /// \brief Load a heightfield, as line geometry.
-MeshData loadHeightfield(const Eigen::MatrixXf &heights,
-                         const Eigen::VectorXf &xgrid,
-                         const Eigen::VectorXf &ygrid);
+MeshData loadHeightfield(const Eigen::Ref<const Eigen::MatrixXf> &heights,
+                         const Eigen::Ref<const Eigen::VectorXf> &xgrid,
+                         const Eigen::Ref<const Eigen::VectorXf> &ygrid);
 } // namespace candlewick

--- a/tests/Ur5.cpp
+++ b/tests/Ur5.cpp
@@ -201,51 +201,48 @@ int main(int argc, char **argv) {
     triad_meshes.push_back(std::move(arrow_mesh));
   }
 
-  GuiSystem guiSys{[&plane_data](Renderer &r) {
-    static bool demo_window_open = true;
+  GuiSystem guiSys{
+      renderer, [&plane_data](Renderer &r) {
+        static bool demo_window_open = true;
 
-    ImGui::Begin("Renderer info & controls", nullptr,
-                 ImGuiWindowFlags_AlwaysAutoResize);
-    ImGui::Text("Device driver: %s", r.device.driverName());
-    ImGui::SeparatorText("Camera");
-    ImGui::RadioButton("Orthographic", (int *)&cam_type,
-                       int(CameraProjection::ORTHOGRAPHIC));
-    ImGui::SameLine();
-    ImGui::RadioButton("Perspective", (int *)&cam_type,
-                       int(CameraProjection::PERSPECTIVE));
-    switch (cam_type) {
-    case CameraProjection::ORTHOGRAPHIC:
-      if (ImGui::DragFloat("zoom", &currentOrthoScale, 0.01f, 0.1f, 2.f, "%.3f",
-                           ImGuiSliderFlags_AlwaysClamp))
-        updateOrtho(currentOrthoScale);
-      break;
-    case CameraProjection::PERSPECTIVE:
-      Degf newFov{currentFov};
-      if (ImGui::DragFloat("fov", newFov, 1.f, 15.f, 90.f, "%.3f",
-                           ImGuiSliderFlags_AlwaysClamp))
-        updateFov(Radf(newFov));
-      break;
-    }
+        ImGui::Begin("Renderer info & controls", nullptr,
+                     ImGuiWindowFlags_AlwaysAutoResize);
+        ImGui::Text("Device driver: %s", r.device.driverName());
+        ImGui::SeparatorText("Camera");
+        ImGui::RadioButton("Orthographic", (int *)&cam_type,
+                           int(CameraProjection::ORTHOGRAPHIC));
+        ImGui::SameLine();
+        ImGui::RadioButton("Perspective", (int *)&cam_type,
+                           int(CameraProjection::PERSPECTIVE));
+        switch (cam_type) {
+        case CameraProjection::ORTHOGRAPHIC:
+          if (ImGui::DragFloat("zoom", &currentOrthoScale, 0.01f, 0.1f, 2.f,
+                               "%.3f", ImGuiSliderFlags_AlwaysClamp))
+            updateOrtho(currentOrthoScale);
+          break;
+        case CameraProjection::PERSPECTIVE:
+          Degf newFov{currentFov};
+          if (ImGui::DragFloat("fov", newFov, 1.f, 15.f, 90.f, "%.3f",
+                               ImGuiSliderFlags_AlwaysClamp))
+            updateFov(Radf(newFov));
+          break;
+        }
 
-    ImGui::SeparatorText("Env. status");
-    ImGui::Checkbox("Render plane", &renderPlane);
-    ImGui::Checkbox("Render grid", &renderGrid);
+        ImGui::SeparatorText("Env. status");
+        ImGui::Checkbox("Render plane", &renderPlane);
+        ImGui::Checkbox("Render grid", &renderGrid);
 
-    ImGui::SeparatorText("Lights");
-    ImGui::DragFloat("intens.", &myLight.intensity, 0.1f, 0.1f, 10.0f);
-    ImGui::ColorEdit3("color", myLight.color.data());
-    ImGui::Separator();
-    ImGui::ColorEdit4("grid color", gridColor.data(),
-                      ImGuiColorEditFlags_AlphaPreview);
-    ImGui::ColorEdit4("plane color", plane_data.material.baseColor.data());
-    ImGui::End();
-    ImGui::SetNextWindowCollapsed(true, ImGuiCond_Once);
-    ImGui::ShowDemoWindow(&demo_window_open);
-  }};
-
-  if (!guiSys.init(renderer)) {
-    return 1;
-  }
+        ImGui::SeparatorText("Lights");
+        ImGui::DragFloat("intens.", &myLight.intensity, 0.1f, 0.1f, 10.0f);
+        ImGui::ColorEdit3("color", myLight.color.data());
+        ImGui::Separator();
+        ImGui::ColorEdit4("grid color", gridColor.data(),
+                          ImGuiColorEditFlags_AlphaPreview);
+        ImGui::ColorEdit4("plane color", plane_data.material.baseColor.data());
+        ImGui::End();
+        ImGui::SetNextWindowCollapsed(true, ImGuiCond_Once);
+        ImGui::ShowDemoWindow(&demo_window_open);
+      }};
 
   // Load robot
   pin::Model model;

--- a/tests/Ur5WithSystems.cpp
+++ b/tests/Ur5WithSystems.cpp
@@ -244,76 +244,76 @@ int main(int argc, char **argv) {
 
   FrustumBoundsDebugSystem frustumBoundsDebug{registry, renderer};
 
-  GuiSystem gui_system{[&](Renderer &r) {
-    static bool demo_window_open = true;
+  GuiSystem gui_system{
+      renderer, [&](Renderer &r) {
+        static bool demo_window_open = true;
 
-    ImGui::Begin("Renderer info & controls", nullptr,
-                 ImGuiWindowFlags_AlwaysAutoResize);
-    ImGui::Text("Device driver: %s", r.device.driverName());
-    ImGui::SeparatorText("Camera");
-    bool ortho_change, persp_change;
-    ortho_change = ImGui::RadioButton("Orthographic", (int *)&cam_type,
-                                      int(CameraProjection::ORTHOGRAPHIC));
-    ImGui::SameLine();
-    persp_change = ImGui::RadioButton("Perspective", (int *)&cam_type,
-                                      int(CameraProjection::PERSPECTIVE));
-    switch (cam_type) {
-    case CameraProjection::ORTHOGRAPHIC:
-      ortho_change |=
-          ImGui::DragFloat("zoom", &currentOrthoScale, 0.01f, 0.1f, 2.f, "%.3f",
-                           ImGuiSliderFlags_AlwaysClamp);
-      if (ortho_change)
-        updateOrtho(currentOrthoScale);
-      break;
-    case CameraProjection::PERSPECTIVE:
-      Degf newFov{currentFov};
-      persp_change |= ImGui::DragFloat("fov", newFov, 1.f, 15.f, 90.f, "%.3f",
-                                       ImGuiSliderFlags_AlwaysClamp);
-      persp_change |=
-          ImGui::SliderFloat("Near plane", &nearZ, 0.01f, 0.8f * farZ);
-      persp_change |= ImGui::SliderFloat("Far plane", &farZ, nearZ, 20.f);
-      if (persp_change)
-        updateFov(Radf(newFov));
-      break;
-    }
+        ImGui::Begin("Renderer info & controls", nullptr,
+                     ImGuiWindowFlags_AlwaysAutoResize);
+        ImGui::Text("Device driver: %s", r.device.driverName());
+        ImGui::SeparatorText("Camera");
+        bool ortho_change, persp_change;
+        ortho_change = ImGui::RadioButton("Orthographic", (int *)&cam_type,
+                                          int(CameraProjection::ORTHOGRAPHIC));
+        ImGui::SameLine();
+        persp_change = ImGui::RadioButton("Perspective", (int *)&cam_type,
+                                          int(CameraProjection::PERSPECTIVE));
+        switch (cam_type) {
+        case CameraProjection::ORTHOGRAPHIC:
+          ortho_change |=
+              ImGui::DragFloat("zoom", &currentOrthoScale, 0.01f, 0.1f, 2.f,
+                               "%.3f", ImGuiSliderFlags_AlwaysClamp);
+          if (ortho_change)
+            updateOrtho(currentOrthoScale);
+          break;
+        case CameraProjection::PERSPECTIVE:
+          Degf newFov{currentFov};
+          persp_change |=
+              ImGui::DragFloat("fov", newFov, 1.f, 15.f, 90.f, "%.3f",
+                               ImGuiSliderFlags_AlwaysClamp);
+          persp_change |=
+              ImGui::SliderFloat("Near plane", &nearZ, 0.01f, 0.8f * farZ);
+          persp_change |= ImGui::SliderFloat("Far plane", &farZ, nearZ, 20.f);
+          if (persp_change)
+            updateFov(Radf(newFov));
+          break;
+        }
 
-    ImGui::SeparatorText("Env. status");
-    ImGui::Checkbox("Render plane", &plane_vis.status);
-    ImGui::Checkbox("Render grid", &grid.enable);
-    ImGui::Checkbox("Render triad", &triad.enable);
-    ImGui::Checkbox("Render frustum", &showFrustum);
+        ImGui::SeparatorText("Env. status");
+        ImGui::Checkbox("Render plane", &plane_vis.status);
+        ImGui::Checkbox("Render grid", &grid.enable);
+        ImGui::Checkbox("Render triad", &triad.enable);
+        ImGui::Checkbox("Render frustum", &showFrustum);
 
-    ImGui::Checkbox("Ambient occlusion (SSAO)", &robot_scene.useSsao);
+        ImGui::Checkbox("Ambient occlusion (SSAO)", &robot_scene.useSsao);
 
-    ImGui::RadioButton("Full render mode", (int *)&showDebugViz, FULL_RENDER);
-    ImGui::SameLine();
-    ImGui::RadioButton("Depth debug", (int *)&showDebugViz, DEPTH_DEBUG);
-    ImGui::SameLine();
-    ImGui::RadioButton("Light mode", (int *)&showDebugViz, LIGHT_DEBUG);
+        ImGui::RadioButton("Full render mode", (int *)&showDebugViz,
+                           FULL_RENDER);
+        ImGui::SameLine();
+        ImGui::RadioButton("Depth debug", (int *)&showDebugViz, DEPTH_DEBUG);
+        ImGui::SameLine();
+        ImGui::RadioButton("Light mode", (int *)&showDebugViz, LIGHT_DEBUG);
 
-    if (showDebugViz & (DEPTH_DEBUG | LIGHT_DEBUG)) {
-      ImGui::RadioButton("Grayscale", (int *)&depth_mode, 0);
-      ImGui::SameLine();
-      ImGui::RadioButton("Heatmap", (int *)&depth_mode, 1);
-    }
+        if (showDebugViz & (DEPTH_DEBUG | LIGHT_DEBUG)) {
+          ImGui::RadioButton("Grayscale", (int *)&depth_mode, 0);
+          ImGui::SameLine();
+          ImGui::RadioButton("Heatmap", (int *)&depth_mode, 1);
+        }
 
-    ImGui::SeparatorText("Lights");
-    ImGui::SliderFloat("intens.", &sceneLight.intensity, 0.1f, 10.0f);
-    ImGui::DragFloat3("direction", sceneLight.direction.data(), 0.0f, -1.f,
-                      1.f);
-    ImGui::ColorEdit3("color", sceneLight.color.data());
-    ImGui::Separator();
-    ImGui::ColorEdit4("grid color", grid.colors[0].data(),
-                      ImGuiColorEditFlags_AlphaPreview);
-    ImGui::ColorEdit4("plane color", plane_obj.materials[0].baseColor.data());
-    ImGui::End();
-    ImGui::SetNextWindowCollapsed(true, ImGuiCond_Once);
-    ImGui::ShowDemoWindow(&demo_window_open);
-  }};
-
-  if (!gui_system.init(renderer)) {
-    return 1;
-  }
+        ImGui::SeparatorText("Lights");
+        ImGui::SliderFloat("intens.", &sceneLight.intensity, 0.1f, 10.0f);
+        ImGui::DragFloat3("direction", sceneLight.direction.data(), 0.0f, -1.f,
+                          1.f);
+        ImGui::ColorEdit3("color", sceneLight.color.data());
+        ImGui::Separator();
+        ImGui::ColorEdit4("grid color", grid.colors[0].data(),
+                          ImGuiColorEditFlags_AlphaPreview);
+        ImGui::ColorEdit4("plane color",
+                          plane_obj.materials[0].baseColor.data());
+        ImGui::End();
+        ImGui::SetNextWindowCollapsed(true, ImGuiCond_Once);
+        ImGui::ShowDemoWindow(&demo_window_open);
+      }};
 
   // MAIN APPLICATION LOOP
 

--- a/tests/Ur5WithSystems.cpp
+++ b/tests/Ur5WithSystems.cpp
@@ -285,7 +285,8 @@ int main(int argc, char **argv) {
         ImGui::Checkbox("Render triad", &triad.enable);
         ImGui::Checkbox("Render frustum", &showFrustum);
 
-        ImGui::Checkbox("Ambient occlusion (SSAO)", &robot_scene.useSsao);
+        ImGui::Checkbox("Ambient occlusion (SSAO)",
+                        &robot_scene.config().enable_ssao);
 
         ImGui::RadioButton("Full render mode", (int *)&showDebugViz,
                            FULL_RENDER);

--- a/tests/Visualizer.cpp
+++ b/tests/Visualizer.cpp
@@ -4,12 +4,14 @@
 
 #include <pinocchio/algorithm/joint-configuration.hpp>
 #include <pinocchio/algorithm/geometry.hpp>
+#include <chrono>
 
 // #include <CLI/App.hpp>
 
 using namespace candlewick::multibody;
+using std::chrono::steady_clock;
 
-int main(int argc, char *argv[]) {
+int main() {
 
   pin::Model model;
   pin::GeometryModel geom_model;
@@ -20,16 +22,20 @@ int main(int argc, char *argv[]) {
 
   Eigen::VectorXd q0 = pin::neutral(model);
   Eigen::VectorXd q1 = pin::randomConfiguration(model);
-  const double dt = 0.04;
 
+  constexpr double dt = 0.04;
+  constexpr std::chrono::duration<double> dt_ms{dt};
+  static_assert(std::same_as<decltype(dt_ms.count()), double>);
   double t = 0.;
 
   while (!visualizer.shouldExit()) {
+    const auto now = steady_clock::now();
 
     double alpha = std::sin(t);
     Eigen::VectorXd q = pin::interpolate(model, q0, q1, alpha);
 
     visualizer.display(q);
+    std::this_thread::sleep_until(now + dt_ms);
 
     t += dt;
   }

--- a/tests/python/test_visualizer.py
+++ b/tests/python/test_visualizer.py
@@ -25,7 +25,7 @@ q0 = pin.neutral(model)
 q1 = pin.randomConfiguration(model)
 
 t = 0.0
-dt = 0.04
+dt = 0.02
 M = pin.SE3.Identity()
 ee_name = "ee_link"
 ee_id = model.getFrameId(ee_name)
@@ -35,8 +35,8 @@ for i in range(1000):
     q = pin.interpolate(model, q0, q1, alpha)
     pin.framesForwardKinematics(model, data, q)
     M = data.oMf[ee_id]
-    viz.setCameraPose(M)
-    viz.setCameraTarget(np.zeros(3))
+    if viz.shouldExit:
+        break
     viz.display(q)
     time.sleep(dt)
     t += dt


### PR DESCRIPTION

This PR makes the Visualizer class, following Pinocchio's Python visualizer API (in C++), asynchronous; it launches the render loop in another thread (a C++11 `std::thread`) where the GPU device and window will be created.

- **core/Renderer.h : add waitForSwapchain(), cancelFrame()**
- **core/Renderer.h : pull sampler functions out of Renderer class**
- **core/Renderer.h : fix taking inline (brace-initialized) C-style array**
- **Update README**
- **core/Renderer : add non-initializing constructor**
- **core/GuiSystem : add direct-initializing ctor, disallow initializing twice**
- **multibody/RobotScene : add enable_ssao to Config struct**
- **multibody/Visualizer : hold robot scene, debug scene as optional<>**
- **[python] expose Visualizer::shouldExit as a property**
- **tests/Visualizer.cpp : do sleep between display() calls**
- **Make Visualizer asynchronous**
