### PR TITLE
Change `robot-descriptions-cpp` to a submodule, only link tests/examples to it

### DIFF
--- a/.gersemirc
+++ b/.gersemirc
@@ -1,4 +1,4 @@
-definitions: [./CMakeLists.txt,./cmake,./src]
+definitions: [./CMakeLists.txt,./cmake,./src,./tests/CMakeLists.txt]
 line_length: 80
 indent: 2
 warn_about_unknown_commands: false

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "external/SDL_gpu_shadercross"]
-	path = external/SDL_gpu_shadercross
-	url = git@github.com:libsdl-org/SDL_gpu_shadercross.git
 [submodule "external/imgui"]
 	path = external/imgui
 	url = git@github.com:ocornut/imgui.git
@@ -10,3 +7,6 @@
 [submodule "doc/doxygen-awesome-css"]
 	path = doc/doxygen-awesome-css
 	url = https://github.com/jothepro/doxygen-awesome-css.git
+[submodule "tests/robot_descriptions_cpp"]
+	path = tests/robot_descriptions_cpp
+	url = https://github.com/ManifoldFR/robot_descriptions_cpp.git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
   autoupdate_schedule: quarterly
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v19.1.7
+    rev: v20.1.0
     hooks:
     - id: clang-format
       types_or: []
@@ -27,12 +27,12 @@ repos:
                 doc/doxygen-awesome.*
             )$
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.9.6'
+    rev: 'v0.9.10'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/BlankSpruce/gersemi
-    rev: 0.19.1
+    rev: 0.19.2
     hooks:
       - id: gersemi

--- a/README.md
+++ b/README.md
@@ -82,9 +82,7 @@ conda install sdl3 eigen magic_enum assimp entt nlohmann_json
   ```
 * [GoogleTest](https://github.com/google/googletest) for the tests | `conda install gtest`
 * [CLI11](https://github.com/CLIUtils/CLI11) for the examples and tests | `conda install cli11`
-* For loading and visualizing robots:
-  * the [Pinocchio](https://github.com/stack-of-tasks/pinocchio) rigid-body dynamics library (required for the `candlewick::multibody` classes and functions) | [conda-forge](https://anaconda.org/conda-forge/pinocchio)
-  * [robot_descriptions_cpp](https://github.com/ManifoldFR/robot_descriptions_cpp), a suite of loaders for robots (required for some examples)
+* The [Pinocchio](https://github.com/stack-of-tasks/pinocchio) rigid-body dynamics library (required for the `candlewick::multibody` classes and functions). Pinocchio must be built with collision support. | [conda-forge](https://anaconda.org/conda-forge/pinocchio)
 
 ## Credits
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,7 +54,6 @@ target_link_libraries(
   PUBLIC
     SDL3::SDL3-shared
     assimp::assimp
-    Eigen3::Eigen
     coal::coal
     magic_enum::magic_enum
     EnTT::EnTT
@@ -95,7 +94,6 @@ target_include_directories(${PROJECT_NAME} INTERFACE candlewick)
 
 if(BUILD_PINOCCHIO_VISUALIZER)
   find_package(pinocchio REQUIRED)
-  find_package(robot_descriptions_cpp REQUIRED)
 
   file(
     GLOB multibody_sources
@@ -108,7 +106,6 @@ if(BUILD_PINOCCHIO_VISUALIZER)
     candlewick_multibody
     PUBLIC
       candlewick_core
-      robot_descriptions_cpp::robot_descriptions_cpp
       pinocchio::pinocchio_default
       pinocchio::pinocchio_visualizers
   )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,8 @@ enable_testing()
 find_package(GTest REQUIRED)
 find_package(CLI11 CONFIG REQUIRED)
 
+add_subdirectory(robot_descriptions_cpp)
+
 add_library(Common STATIC lib/Common.cpp lib/PerlinNoise.cpp)
 target_link_libraries(Common PUBLIC candlewick_core)
 target_include_directories(Common PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/lib)
@@ -11,7 +13,7 @@ if(BUILD_PINOCCHIO_VISUALIZER)
   target_link_libraries(Common PUBLIC candlewick_multibody)
 endif()
 
-function(create_test filename)
+function(add_candlewick_example filename)
   cmake_path(GET filename STEM name)
   add_executable(${name} ${filename})
   foreach(arg ${ARGN})
@@ -20,12 +22,17 @@ function(create_test filename)
   endforeach()
 endfunction()
 
-create_test(Triangle.cpp Common)
-create_test(ColoredCube.cpp Common)
-create_test(MeshNormalsRgb.cpp Common)
-create_test(LitMesh.cpp Common)
-
-create_test(Ur5WithSystems.cpp Common CLI11::CLI11)
-create_test(Visualizer.cpp Common)
-
-create_test(TestVertexBlob.cpp candlewick_core GTest::gtest_main)
+add_candlewick_example(Triangle.cpp Common)
+add_candlewick_example(ColoredCube.cpp Common)
+add_candlewick_example(MeshNormalsRgb.cpp Common)
+add_candlewick_example(LitMesh.cpp Common)
+if(BUILD_PINOCCHIO_VISUALIZER)
+  add_candlewick_example(
+    Ur5WithSystems.cpp
+    Common
+    CLI11::CLI11
+    robot_descriptions_cpp
+  )
+  add_candlewick_example(Visualizer.cpp Common robot_descriptions_cpp)
+endif()
+add_candlewick_example(TestVertexBlob.cpp candlewick_core GTest::gtest_main)


### PR DESCRIPTION
This PR changes how we integrate my C++ robot descriptions loader
- it's now a submodule
- we don't link the `candlewick_multibody` target to it